### PR TITLE
Add console monitor and use state.message as array.

### DIFF
--- a/demo/basic/beedle.js
+++ b/demo/basic/beedle.js
@@ -32,9 +32,19 @@ export default class Store {
                 // Set the value as we would normally
                 state[key] = value;
 
+                // Trace out to the console.
+                // This will be grouped by the related action.
+
+                console.log(`stateChange: ${key}: ${value}`);
+
                 // Fire off our callback processor because if there's listeners, 
                 // they're going to want to know that something has changed
                 self.processCallbacks(self.state);
+
+                // Warn the user if they set a value directly.
+                if (self.status !== 'mutation') {
+                    console.warn(`You should use a mutation to set ${key}`);
+                }
                 
                 // Reset the status ready for the next operation
                 self.status = 'resting';
@@ -63,12 +73,18 @@ export default class Store {
             console.error(`Action "${actionKey}" doesn't exist.`);
             return false;
         }
+
+        // Create a console group which will contain logs from our Proxy, etc.
+        console.groupCollapsed(`ACTION: ${actionKey}`);
         
         // Let anything that's watching the status know that we're dispatching an action
         self.status = 'action';
         
         // Actually call the action and pass it the Store context and whatever payload was passed
         self.actions[actionKey](self, payload);
+
+        // Close our console group (keep things nice and neat).
+        console.groupEnd();
 
         return true;
     }

--- a/demo/basic/main.js
+++ b/demo/basic/main.js
@@ -9,14 +9,14 @@ const actions = {
 
 const mutations = {
     setMessage(state, payload) {
-        state.message = payload;
+        state.message[0] = payload;
 
         return state;
     }
 };
 
 const initialState = {
-   message: 'Hello, world'
+   message: ['Hello, world']
 };
 
 // Create our store instance
@@ -41,5 +41,5 @@ const messageElement = document.querySelector('.js-message-element');
 
 // This fires every time the state updates
 storeInstance.subscribe(state => {
-    messageElement.innerText = state.message;
+    messageElement.innerText = state.message[0];
 });


### PR DESCRIPTION
## Possible issue with example demo/basic

Hi, studied your CssTricks tutorial as well as your beedle very carefully and for days now, and learned a lot - Thank you very much !!  

However, maybe I found a possible issue with beedle.js. 

To "show you some code" I forked beedle and added the deputy branch where a git diff will instantly show you what otherwise could be a thousand words.

## A brief summary of what the changes do
<-- Mention how they improve the library and how that happens -->
1. In beedle.js : Re-introduce the console.group monitoring from CSS-TRICKS tutorial.
2. This shows for demo/basic that setMessage is called TWICE for each action-dispatch
    - First while still in resting state
    - Second, while in commit method , i. e. , in mutation state.
    - You'll get appropriate warnings in the re-introduced console.group for the action.
3. Turns out, this stems from directly modifying state.message = 'blah' in the mutation.
4. This can be mitigated using state.message[0] = 'blah' (now as an array) inside the mutation.

Thank you very much,
Regards, M.
