### PR TITLE
Fix/unit tests

### DIFF
--- a/test/src/beedle.js
+++ b/test/src/beedle.js
@@ -21,7 +21,7 @@ const storeInstance = new Store({
     initialState,
     actions: {
         runUpdate(context, payload) {
-            context.commit('updateState', payload);
+            return context.commit('updateState', payload);
         }    
     },
     mutations: {


### PR DESCRIPTION
This update fixes the first test that was failing by returning `context.commit` from `runUpdate`. Previously it was `undefined` but the test was expecting `true`.
