### PR TITLE
Update beedle.js

### DIFF
--- a/src/beedle.js
+++ b/src/beedle.js
@@ -26,22 +26,30 @@ export default class Store {
         // Set our state to be a Proxy. We are setting the default state by
         // checking the params and defaulting to an empty object if no default
         // state is passed in
-        self.state = new Proxy((params.initialState || {}), {
-            set(state, key, value) {
-
-                // Set the value as we would normally
-                state[key] = value;
-
-                // Fire off our callback processor because if there's listeners,
-                // they're going to want to know that something has changed
-                self.processCallbacks(self.state);
-
-                // Reset the status ready for the next operation
-                self.status = 'resting';
-
-                return true;
+        const handler = {
+          get: (target, key) => {
+            if (typeof target[key] === "object" && target[key] !== null) {
+              return new Proxy(target[key], handler);
+            } else {
+              return target[key];
             }
-        });
+          },
+          set(state, key, value) {
+            // Set the value as we would normally
+            state[key] = value;
+
+            // Fire off our callback processor because if there's listeners,
+            // they're going to want to know that something has changed
+            self.processCallbacks(self.state);
+
+            // Reset the status ready for the next operation
+            self.status = "resting";
+
+            return true;
+          }
+        };
+
+        self.state = new Proxy(params.initialState || {}, handler);
     }
 
     /**


### PR DESCRIPTION
## Proposed Changes
- Support nested proxies

## A brief summary of what the changes do
This PR allows nested proxies so we can add multiple modules, similar to redux named modules.

ie.
```
const initalState = {
       foo: {
             bar: []
       }
}
```
ie. combined modules
```
// Combine all the different actions / mutations / state
const combindedStore = Object.values(modules).reduce(
  (acc, m) => {
    Object.assign(acc.actions, m.actions);
    Object.assign(acc.mutations, m.mutations);
    Object.assign(acc.initialState, m.initialState);
    return acc;
  },
  {
    actions: {},
    mutations: {},
    initialState: {}
  }
);

export const store = new Store({
  actions: combindedStore.actions,
  mutations: combindedStore.mutations,
  initialState: combindedStore.initialState
});
```

